### PR TITLE
Add examples and improve callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
 # Stop dispatcher
 
+Stop dispatcher can be used to manage Golang application gracefull shutdown. 
+It allow you to register application shutdown callback (to close some database connection, clean temp folder ...)
+You can event use it in sub process to manage when operation end up normally or when it failed.
+
 ## Installation
 
 `go get -u github.com/gol4ng/stop-dispatcher`
+
+### Examples
+
+A runner application (like http server)
 
 ```go
 package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	stop_dispatcher "github.com/gol4ng/stop-dispatcher"
@@ -23,11 +32,21 @@ func main() {
 	// stop dispatcher with log reason handler
 	stopDispatcher := stop_dispatcher.NewDispatcher(
 		stop_dispatcher.WithReasonHandler(reason_handler.Log()),
+		stop_dispatcher.WithEmitter(
+			// Listen SIGINT, SIGTERM
+			stop_emitter.DefaultKillerSignalEmitter(),
+		),
 	)
 
 	// Register a killer signal emitter
 	stopDispatcher.RegisterEmitter(
-		stop_emitter.DefaultKillerSignalEmitter(),
+		// Start the job 
+		func(stop func(reason stop_dispatcher.Reason)) {
+			for i := 0; i < 10; i++ {
+				fmt.Printf("%d time elapsed\n", i)
+			}
+			stop("process finished")
+		},
 	)
 
 	// Register all your stopping callback
@@ -36,8 +55,76 @@ func main() {
 			log.Println("Closing all database connection")
 			return nil
 		},
+	)
+
+	// Wait will block until stopping reason was received
+	if err := stopDispatcher.Wait(ctx); err != nil {
+		log.Printf("error occured during stopping application : %s", err)
+	}
+	log.Println("Application stopped")
+}
+```
+
+A job application (will perfom a task then end)
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+
+	stop_dispatcher "github.com/gol4ng/stop-dispatcher"
+	"github.com/gol4ng/stop-dispatcher/reason_handler"
+	"github.com/gol4ng/stop-dispatcher/stop_emitter"
+)
+
+func main() {
+	// root context
+	ctx := context.Background()
+
+	// stop dispatcher with log reason handler
+	stopDispatcher := stop_dispatcher.NewDispatcher(
+		stop_dispatcher.WithReasonHandler(reason_handler.Log()),
+		stop_dispatcher.WithEmitter(
+			// Listen SIGINT, SIGTERM
+			stop_emitter.DefaultKillerSignalEmitter(),
+		),
+	)
+
+	i := int64(0)
+	httpServer := &http.Server{
+		Handler:        http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			writer.Write([]byte(strconv.Itoa(int(atomic.LoadInt64(&i)))))
+			atomic.AddInt64(&i, 1)
+		}),
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
+	}
+
+	// Register a killer signal emitter
+	stopDispatcher.RegisterEmitter(
+		// Start the httpServer and listen when it stop
+		func(stop func(reason stop_dispatcher.Reason)) {
+			if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				stop(fmt.Errorf("http server[%s] : %w", httpServer.Addr, err))
+			}
+		},
+	)
+
+	// Register all your stopping callback
+	stopDispatcher.RegisterCallbacks(
 		func(ctx context.Context) error {
-			log.Println("Closing all server connection")
+			return httpServer.Shutdown(ctx)
+		},
+		func(ctx context.Context) error {
+			log.Println("Closing all database connection")
 			return nil
 		},
 	)

--- a/stop_emitter/signal_test.go
+++ b/stop_emitter/signal_test.go
@@ -3,6 +3,7 @@ package stop_emitter
 import (
 	"os"
 	"strconv"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -19,11 +20,11 @@ func (s FakeSignal) String() string {
 }
 
 func TestDefaultSignalEmitter(t *testing.T) {
-	stopCalled := false
-	signalNotifyCalled := false
+	stopCalled := NewSafeBool(false)
+	signalNotifyCalled := NewSafeBool(false)
 	// replace local signalNotify function
 	signalNotify = func(c chan<- os.Signal, sig ...os.Signal) {
-		signalNotifyCalled = true
+		signalNotifyCalled.Set(true)
 		assert.Equal(t, []os.Signal{syscall.SIGINT, syscall.SIGTERM}, sig)
 		c <- FakeSignal(1)
 	}
@@ -31,23 +32,23 @@ func TestDefaultSignalEmitter(t *testing.T) {
 	fn := DefaultSignalEmitter()
 	wait := make(chan struct{})
 	go fn(func(reason stop_dispatcher.Reason) {
-		stopCalled = true
+		stopCalled.Set(true)
 		assert.Equal(t, FakeSignal(1), reason)
 		close(wait)
 	})
 	<-wait
-	assert.True(t, stopCalled)
-	assert.True(t, signalNotifyCalled)
+	assert.True(t, stopCalled.Get())
+	assert.True(t, signalNotifyCalled.Get())
 }
 
 func TestSignalEmitter(t *testing.T) {
-	stopCalled := false
-	signalNotifyCalled := false
+	stopCalled := NewSafeBool(false)
+	signalNotifyCalled := NewSafeBool(false)
 	subscribedSignals := []os.Signal{FakeSignal(1), FakeSignal(2)}
 
 	// replace local signalNotify function
 	signalNotify = func(c chan<- os.Signal, sig ...os.Signal) {
-		signalNotifyCalled = true
+		signalNotifyCalled.Set(true)
 		assert.Equal(t, subscribedSignals, sig)
 		c <- FakeSignal(1)
 	}
@@ -55,28 +56,28 @@ func TestSignalEmitter(t *testing.T) {
 	fn := SignalEmitter(subscribedSignals...)
 	wait := make(chan struct{})
 	go fn(func(reason stop_dispatcher.Reason) {
-		stopCalled = true
+		stopCalled.Set(true)
 		assert.Equal(t, FakeSignal(1), reason)
 		close(wait)
 	})
 	<-wait
-	assert.True(t, stopCalled)
-	assert.True(t, signalNotifyCalled)
+	assert.True(t, stopCalled.Get())
+	assert.True(t, signalNotifyCalled.Get())
 }
 
 func TestDefaultKillerSignalEmitter(t *testing.T) {
-	osExitCalled := false
-	stopCalled := false
-	signalNotifyCalled := false
+	osExitCalled := NewSafeBool(false)
+	stopCalled := NewSafeBool(false)
+	signalNotifyCalled := NewSafeBool(false)
 
 	// replace local osExit function
 	osExit = func(code int) {
-		osExitCalled = true
+		osExitCalled.Set(true)
 		assert.Equal(t, 1, code)
 	}
 	// replace local signalNotify function
 	signalNotify = func(c chan<- os.Signal, sig ...os.Signal) {
-		signalNotifyCalled = true
+		signalNotifyCalled.Set(true)
 		assert.Equal(t, []os.Signal{syscall.SIGINT, syscall.SIGTERM}, sig)
 		c <- FakeSignal(1)
 		c <- FakeSignal(1)
@@ -85,32 +86,32 @@ func TestDefaultKillerSignalEmitter(t *testing.T) {
 	fn := DefaultKillerSignalEmitter()
 	wait := make(chan struct{})
 	go fn(func(reason stop_dispatcher.Reason) {
-		stopCalled = true
+		stopCalled.Set(true)
 		assert.Equal(t, FakeSignal(1), reason)
 		close(wait)
 	})
 	<-wait
-	assert.True(t, osExitCalled)
-	assert.True(t, stopCalled)
-	assert.True(t, signalNotifyCalled)
+	assert.True(t, osExitCalled.Get())
+	assert.True(t, stopCalled.Get())
+	assert.True(t, signalNotifyCalled.Get())
 }
 
 func TestKillerSignalEmitter(t *testing.T) {
-	osExitCalled := false
-	stopCalled := false
-	signalNotifyCalled := false
+	osExitCalled := NewSafeBool(false)
+	stopCalled := NewSafeBool(false)
+	signalNotifyCalled := NewSafeBool(false)
 	subscribedSignals := []os.Signal{FakeSignal(1), FakeSignal(2)}
 
 	// replace local signalNotify function
 	osExit = func(code int) {
-		osExitCalled = true
+		osExitCalled.Set(true)
 		assert.Equal(t, 1, code)
 	}
 	// replace local signalNotify function
 	signalNotify = func(c chan<- os.Signal, sig ...os.Signal) {
-		signalNotifyCalled = true
+		signalNotifyCalled.Set(true)
 		assert.Equal(t, subscribedSignals, sig)
-		assert.False(t, osExitCalled)
+		assert.False(t, osExitCalled.Get())
 		c <- FakeSignal(1)
 		c <- FakeSignal(1)
 	}
@@ -118,12 +119,34 @@ func TestKillerSignalEmitter(t *testing.T) {
 	fn := KillerSignalEmitter(subscribedSignals...)
 	wait := make(chan struct{})
 	go fn(func(reason stop_dispatcher.Reason) {
-		stopCalled = true
+		stopCalled.Set(true)
 		assert.Equal(t, FakeSignal(1), reason)
 		close(wait)
 	})
 	<-wait
-	assert.True(t, osExitCalled)
-	assert.True(t, stopCalled)
-	assert.True(t, signalNotifyCalled)
+	assert.True(t, osExitCalled.Get())
+	assert.True(t, stopCalled.Get())
+	assert.True(t, signalNotifyCalled.Get())
+}
+
+type SafeBool struct {
+	b  bool
+	mu sync.RWMutex
+}
+
+func (s *SafeBool) Get() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.b
+}
+func (s *SafeBool) Set(b bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.b = b
+}
+func NewSafeBool(b bool) *SafeBool {
+	return &SafeBool{
+		b:  b,
+		mu: sync.RWMutex{},
+	}
 }


### PR DESCRIPTION
Add 2 examples in the readme of a **runner**(like server) and **non runner**(command, jobs) application

## ⚠️ BC Break  

`RegisterCallback(stopCallbacks ...Callback)` as move to `RegisterCallbacks(stopCallbacks ...Callback)`
new signature method `RegisterCallback(stopCallback Callback) func()`

## Migration 

if you use `RegisterCallback(stopCallbacks ...Callback)` just replace with `RegisterCallbacks(stopCallbacks ...Callback)`