### PR TITLE
Prioritized callback

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -2,25 +2,54 @@ package stop_dispatcher
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	local_error "github.com/gol4ng/stop-dispatcher/error"
 )
 
 // use to replace the callback when they unregistered
-var nopFunc = func(ctx context.Context) error { return nil }
+var nopFunc = CallbackFunc(func(ctx context.Context) error { return nil })
 
 // Reason is the stopping given value
 type Reason interface{}
 
 // Emitter can emit a reason that will be dispatched
-type Emitter func(func(Reason))
+type Emitter func(ReasonHandler)
 
 // It receive the emitted stop reason before calling callbacks
 type ReasonHandler func(Reason)
 
-// Callback will be called when a reason raised from Emitter
-type Callback func(ctx context.Context) error
+// CallbackFunc will be called when a reason raised from Emitter
+type CallbackFunc func(ctx context.Context) error
+
+func (c CallbackFunc) GetPriority() int {
+	return 0
+}
+func (c CallbackFunc) Callback(ctx context.Context) error {
+	return c(ctx)
+}
+
+type Callback interface {
+	GetPriority() int
+	Callback(ctx context.Context) error
+}
+
+type PrioritizedCallback struct {
+	CallbackFunc
+	priority int
+}
+
+func (c PrioritizedCallback) GetPriority() int {
+	return c.priority
+}
+
+func NewPrioritizeCallback(priority int, callback CallbackFunc) Callback {
+	return PrioritizedCallback{
+		CallbackFunc: callback,
+		priority:     priority,
+	}
+}
 
 // Dispatcher implementation provide Reason dispatcher
 type Dispatcher struct {
@@ -42,6 +71,22 @@ func (t *Dispatcher) RegisterEmitter(stopEmitters ...Emitter) {
 	for _, stopEmitter := range stopEmitters {
 		go stopEmitter(t.Stop)
 	}
+}
+
+func (t *Dispatcher) RegisterPrioritizeCallbackFunc(priority int, stopCallback CallbackFunc) func() {
+	return t.RegisterCallback(NewPrioritizeCallback(priority, stopCallback))
+}
+
+func (t *Dispatcher) RegisterCallbackFunc(stopCallback CallbackFunc) func() {
+	return t.RegisterCallback(stopCallback)
+}
+
+func (t *Dispatcher) RegisterCallbacksFunc(stopCallbacks ...CallbackFunc) {
+	callbacks := make([]Callback, len(stopCallbacks))
+	for i, c := range stopCallbacks {
+		callbacks[i] = c
+	}
+	t.RegisterCallbacks(callbacks...)
 }
 
 // RegisterCallback is used to register stopping callback
@@ -77,9 +122,12 @@ func (t *Dispatcher) Wait(ctx context.Context) error {
 	errs := local_error.List{}
 	t.mu.RLock()
 	stopCallbacks := t.stopCallbacks
-	defer t.mu.RUnlock()
+	t.mu.RUnlock()
+	sort.Slice(stopCallbacks, func(i, j int) bool {
+		return stopCallbacks[i].GetPriority() > stopCallbacks[j].GetPriority()
+	})
 	for _, fn := range stopCallbacks {
-		if err := fn(shutdownCtx); err != nil {
+		if err := fn.Callback(shutdownCtx); err != nil {
 			errs.Add(err)
 		}
 	}

--- a/stop_callback/timeout.go
+++ b/stop_callback/timeout.go
@@ -14,7 +14,7 @@ var osExit = os.Exit
 
 // Timeout will exit if the timeout exceed
 func Timeout(timeout time.Duration) stop_dispatcher.Callback {
-	return stop_dispatcher.CallbackFunc(func(ctx context.Context) error {
+	return stop_dispatcher.NewPrioritizeCallback(1000, func(ctx context.Context) error {
 		time.AfterFunc(timeout, func() {
 			log.Printf("Shutdown timeout exceeded %s", timeout)
 			osExit(1)

--- a/stop_callback/timeout.go
+++ b/stop_callback/timeout.go
@@ -14,11 +14,11 @@ var osExit = os.Exit
 
 // Timeout will exit if the timeout exceed
 func Timeout(timeout time.Duration) stop_dispatcher.Callback {
-	return func(ctx context.Context) error {
+	return stop_dispatcher.CallbackFunc(func(ctx context.Context) error {
 		time.AfterFunc(timeout, func() {
 			log.Printf("Shutdown timeout exceeded %s", timeout)
 			osExit(1)
 		})
 		return nil
-	}
+	})
 }

--- a/stop_callback/timeout_test.go
+++ b/stop_callback/timeout_test.go
@@ -23,7 +23,7 @@ func TestTimedout(t *testing.T) {
 	}
 
 	fn := Timeout(100 * time.Millisecond)
-	assert.Nil(t, fn(context.TODO()))
+	assert.Nil(t, fn.Callback(context.TODO()))
 	time.Sleep(200 * time.Millisecond)
 	assert.Equal(t, "Shutdown timeout exceeded 100ms\n", buf.String())
 }

--- a/stop_emitter/signal.go
+++ b/stop_emitter/signal.go
@@ -19,7 +19,7 @@ func DefaultSignalEmitter() stop_dispatcher.Emitter {
 
 // SignalEmitter will emit stop reason when signal was received
 func SignalEmitter(signals ...os.Signal) stop_dispatcher.Emitter {
-	return func(stop func(stop_dispatcher.Reason)) {
+	return func(stop stop_dispatcher.ReasonHandler) {
 		signalChan := make(chan os.Signal, 1)
 		signalNotify(signalChan, signals...)
 		stop(<-signalChan)
@@ -35,7 +35,7 @@ func DefaultKillerSignalEmitter() stop_dispatcher.Emitter {
 // KillerSignalEmitter will emit stop reason when signal was received
 // it exit if signal was received a second time
 func KillerSignalEmitter(signals ...os.Signal) stop_dispatcher.Emitter {
-	return func(stop func(stop_dispatcher.Reason)) {
+	return func(stop stop_dispatcher.ReasonHandler) {
 		signalReceived := false
 		signalChan := make(chan os.Signal, 2)
 		signalNotify(signalChan, signals...)


### PR DESCRIPTION
## ⚠️ Warning BC Break:

- `type Emitter func(func(Reason))` >> `type Emitter func(ReasonHandler)`
- `type Callback func(ctx context.Context) error`  >>  `type CallbackFunc func(ctx context.Context) error`

## Note 

- **highest priority will be executed first**
- **callback with equal priority will be executed in the register order (first register = first execute)**

## Migration note

`d.RegisterCallback(func(ctx context.Context) error {` 
Become
`d.RegisterCallbackFunc(func(ctx context.Context) error {`
or
`d.RegisterPrioritizeCallbackFunc(0, func(ctx context.Context) error {`